### PR TITLE
Fix indentation in enumeration setup script.

### DIFF
--- a/enumeration/setup.py
+++ b/enumeration/setup.py
@@ -31,7 +31,7 @@ def createList(ipadr):
                 line = line.split(" ")
                 if re.match('[a-zA-Z]',line[1]) is None:
                         fo.write("%s\n" % (line[1]))
-    fo.close()
+   fo.close()
 
 def upnsedb(url):
     NSE = "wget -c %s -P %s" % (url, reconf.nsepth)


### PR DESCRIPTION
This resolves a typo that will throw an IndentationError when executing ./enumeration/setup.py.